### PR TITLE
FE-017: 合并并落地 ProtectedRoute 到 develop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
-import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-dom";
 import ThemeProvider from "@/components/ThemeProvider";
+import { ProtectedRoute } from "@/components/ProtectedRoute";
 import { initializeAuth } from "@/store/authStore";
 import AppLayout from "@/layouts/AppLayout";
 import AdminLayout from "@/layouts/AdminLayout";
@@ -12,6 +13,7 @@ import AccountPage from "@/pages/AccountPage";
 import AdminDashboardPage from "@/pages/AdminDashboardPage";
 import CreateArticlePage from "@/pages/CreateArticlePage";
 import EditArticlePage from "@/pages/EditArticlePage";
+import UnauthorizedPage from "@/pages/UnauthorizedPage";
 
 export default function App() {
   // 初始化认证状态
@@ -29,15 +31,27 @@ export default function App() {
             <Route path="/articles" element={<ArticlesPage />} />
             <Route path="/article/:id" element={<ArticleDetailPage />} />
             <Route path="/article/:postId/comment/:commentId/replies" element={<ReplyDetailPage />} />
-            <Route path="/account" element={<AccountPage />} />
+            <Route path="/unauthorized" element={<UnauthorizedPage />} />
           </Route>
 
-          {/* 后台管理路由 */}
-          <Route element={<AdminLayout />}>
-            <Route path="/admin" element={<AdminDashboardPage />} />
-            <Route path="/admin/create" element={<CreateArticlePage />} />
-            <Route path="/admin/edit/:id" element={<EditArticlePage />} />
+          {/* 需要登录的路由 - 个人账户 */}
+          <Route element={<ProtectedRoute />}>
+            <Route element={<AppLayout />}>
+              <Route path="/account" element={<AccountPage />} />
+            </Route>
           </Route>
+
+          {/* 管理员路由 - 需要 admin 角色 */}
+          <Route element={<ProtectedRoute allowedRoles={["admin", "superadmin"]} />}>
+            <Route element={<AdminLayout />}>
+              <Route path="/admin" element={<AdminDashboardPage />} />
+              <Route path="/admin/create" element={<CreateArticlePage />} />
+              <Route path="/admin/edit/:id" element={<EditArticlePage />} />
+            </Route>
+          </Route>
+
+          {/* 默认重定向 */}
+          <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </Router>
     </ThemeProvider>

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -30,9 +30,40 @@ export function ProtectedRoute({
     );
   }
 
-  // 已登录但角色不匹配：重定向到无权限页面
-  if (allowedRoles && user && !allowedRoles.includes(user.role as UserRole)) {
-    return <Navigate to="/unauthorized" replace />;
+  // 🛡️ 兜底检查：isLoggedIn=true 但 user 为 null（异常状态）
+  if (!user) {
+    console.warn(
+      "[ProtectedRoute] 异常状态检测：isLoggedIn=true 但 user 为 null，重定向至登录",
+      { isLoggedIn, user }
+    );
+    return (
+      <Navigate
+        to={`${redirectTo}?redirect=${encodeURIComponent(location.pathname)}`}
+        state={{ from: location }}
+        replace
+      />
+    );
+  }
+
+  // 🛡️ 需要特定角色时的权限检查（显式处理）
+  if (allowedRoles) {
+    // 兜底检查：user.role 缺失（值为 undefined 或其他异常值）
+    if (!user.role) {
+      console.warn(
+        "[ProtectedRoute] 权限异常：已登录但 user.role 缺失，拒绝访问",
+        { user, allowedRoles, path: location.pathname }
+      );
+      return <Navigate to="/unauthorized" replace />;
+    }
+
+    // 显式检查权限是否匹配
+    if (!allowedRoles.includes(user.role as UserRole)) {
+      console.warn(
+        "[ProtectedRoute] 权限不足：用户角色不在允许列表中",
+        { userRole: user.role, allowedRoles, path: location.pathname }
+      );
+      return <Navigate to="/unauthorized" replace />;
+    }
   }
 
   // 通过验证：渲染子路由

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,40 @@
+import { Navigate, Outlet, useLocation } from "react-router-dom";
+import { useAuthStore } from "@/store/authStore";
+import type { UserRole } from "@/types/auth";
+
+interface ProtectedRouteProps {
+  allowedRoles?: UserRole[];
+  redirectTo?: string;
+}
+
+/**
+ * 路由守卫组件 - 保护需要登录的页面
+ * @param allowedRoles - 允许访问的角色列表，不提供则只需登录
+ * @param redirectTo - 未授权时重定向的路径，默认为 /
+ */
+export function ProtectedRoute({
+  allowedRoles,
+  redirectTo = "/",
+}: ProtectedRouteProps) {
+  const { isLoggedIn, user } = useAuthStore();
+  const location = useLocation();
+
+  // 未登录：重定向到首页，保存当前路径用于登录后跳转
+  if (!isLoggedIn) {
+    return (
+      <Navigate
+        to={`${redirectTo}?redirect=${encodeURIComponent(location.pathname)}`}
+        state={{ from: location }}
+        replace
+      />
+    );
+  }
+
+  // 已登录但角色不匹配：重定向到无权限页面
+  if (allowedRoles && user && !allowedRoles.includes(user.role as UserRole)) {
+    return <Navigate to="/unauthorized" replace />;
+  }
+
+  // 通过验证：渲染子路由
+  return <Outlet />;
+}

--- a/src/pages/UnauthorizedPage.tsx
+++ b/src/pages/UnauthorizedPage.tsx
@@ -1,0 +1,40 @@
+import { useNavigate } from "react-router-dom";
+
+export default function UnauthorizedPage() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[60vh] gap-6 px-4">
+      <div className="text-center">
+        <h1 className="text-6xl font-bold text-red-600 dark:text-red-400 mb-4">403</h1>
+        <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-2">
+          访问被拒绝
+        </h2>
+        <p className="text-gray-600 dark:text-gray-400 text-lg">
+          您没有权限访问此页面。
+        </p>
+      </div>
+
+      <div className="flex gap-4 mt-8">
+        <button
+          onClick={() => navigate(-1)}
+          className="px-6 py-2 bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-white rounded-lg font-medium hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
+        >
+          返回上一页
+        </button>
+        <button
+          onClick={() => navigate("/")}
+          className="px-6 py-2 bg-blue-600 dark:bg-blue-700 text-white rounded-lg font-medium hover:bg-blue-700 dark:hover:bg-blue-600 transition-colors"
+        >
+          返回首页
+        </button>
+      </div>
+
+      <div className="mt-12 max-w-md p-6 bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-800">
+        <p className="text-sm text-blue-900 dark:text-blue-200">
+          💡 提示：如果您认为这是一个错误，请联系管理员。
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,6 +1,13 @@
 import { create } from "zustand";
 import type { AuthUser, LoginForm, RegisterForm } from "@/types/auth";
 
+function normalizeAuthUser(user: AuthUser): AuthUser {
+  return {
+    ...user,
+    role: user.role ?? "user",
+  };
+}
+
 interface AuthStore {
   user: AuthUser | null;
   isLoading: boolean;
@@ -60,6 +67,7 @@ export const useAuthStore = create<AuthStore>((set) => ({
         username: form.email.split("@")[0] ?? "",
         email: form.email,
         avatar: "https://api.dicebear.com/7.x/avataaars/svg?seed=" + form.email,
+        role: "user",
       };
 
       set({
@@ -116,6 +124,7 @@ export const useAuthStore = create<AuthStore>((set) => ({
         username: form.username,
         email: form.email,
         avatar: "https://api.dicebear.com/7.x/avataaars/svg?seed=" + form.email,
+        role: "user",
       };
 
       set({
@@ -154,7 +163,7 @@ export const useAuthStore = create<AuthStore>((set) => ({
   },
 
   setUser: (user: AuthUser) => {
-    set({ user, isLoggedIn: true });
+    set({ user: normalizeAuthUser(user), isLoggedIn: true });
   },
 
   updateAvatar: (avatarUrl: string) => {
@@ -181,7 +190,7 @@ export const initializeAuth = () => {
   try {
     const savedUser = localStorage.getItem("blog-auth-user");
     if (savedUser) {
-      const user = JSON.parse(savedUser) as AuthUser;
+      const user = normalizeAuthUser(JSON.parse(savedUser) as AuthUser);
       useAuthStore.setState({ user, isLoggedIn: true });
     }
   } catch (e) {

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,8 +1,11 @@
+export type UserRole = "user" | "admin" | "superadmin";
+
 export type AuthUser = {
   id: number;
   username: string;
   email: string;
   avatar?: string;
+  role: UserRole;
 };
 
 export type LoginForm = {


### PR DESCRIPTION
- 引入 ProtectedRoute 与 UnauthorizedPage\n- 将 /account 与 /admin 按登录/角色进行路由守卫\n- 补齐 AuthUser 的 role 字段，避免本地登录态缺失角色导致误拦截\n\n验证：bun run build\n\nCloses #23