### PR TITLE
FE-019: 路由守卫补齐 Hydration 等待与加载态（避免首屏误跳转）

### DIFF
--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,4 +1,5 @@
 import { Navigate, Outlet, useLocation } from "react-router-dom";
+import { useHydration } from "@/hooks/useHydration";
 import { useAuthStore } from "@/store/authStore";
 import type { UserRole } from "@/types/auth";
 
@@ -16,8 +17,20 @@ export function ProtectedRoute({
   allowedRoles,
   redirectTo = "/",
 }: ProtectedRouteProps) {
+  const hasHydrated = useHydration();
   const { isLoggedIn, user } = useAuthStore();
   const location = useLocation();
+
+  if (!hasHydrated) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center px-4">
+        <div className="flex items-center gap-3 rounded-xl border border-gray-200 bg-white/90 px-5 py-4 shadow-sm dark:border-gray-700 dark:bg-gray-900/90">
+          <div className="h-5 w-5 animate-spin rounded-full border-2 border-blue-600 border-t-transparent" />
+          <p className="text-sm font-medium text-gray-600 dark:text-gray-300">正在恢复登录状态...</p>
+        </div>
+      </div>
+    );
+  }
 
   // 未登录：重定向到首页，保存当前路径用于登录后跳转
   if (!isLoggedIn) {

--- a/src/hooks/useHydration.ts
+++ b/src/hooks/useHydration.ts
@@ -1,0 +1,5 @@
+import { useAuthStore } from "@/store/authStore";
+
+export function useHydration() {
+  return useAuthStore((state) => state.hasHydrated);
+}

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -13,6 +13,7 @@ interface AuthStore {
   isLoading: boolean;
   error: string | null;
   isLoggedIn: boolean;
+  hasHydrated: boolean;
 
   // 登录
   login: (form: LoginForm) => Promise<void>;
@@ -41,6 +42,7 @@ export const useAuthStore = create<AuthStore>((set) => ({
   isLoading: false,
   error: null,
   isLoggedIn: false,
+  hasHydrated: false,
 
   login: async (form: LoginForm) => {
     set({ isLoading: true, error: null });
@@ -74,6 +76,7 @@ export const useAuthStore = create<AuthStore>((set) => ({
         user: mockUser,
         isLoggedIn: true,
         isLoading: false,
+        hasHydrated: true,
       });
 
       // 保存到 localStorage
@@ -86,6 +89,7 @@ export const useAuthStore = create<AuthStore>((set) => ({
       set({
         error: error instanceof Error ? error.message : "登录失败",
         isLoading: false,
+        hasHydrated: true,
       });
       throw error;
     }
@@ -131,6 +135,7 @@ export const useAuthStore = create<AuthStore>((set) => ({
         user: mockUser,
         isLoggedIn: true,
         isLoading: false,
+        hasHydrated: true,
       });
 
       // 保存到 localStorage
@@ -143,13 +148,14 @@ export const useAuthStore = create<AuthStore>((set) => ({
       set({
         error: error instanceof Error ? error.message : "注册失败",
         isLoading: false,
+        hasHydrated: true,
       });
       throw error;
     }
   },
 
   logout: () => {
-    set({ user: null, isLoggedIn: false, error: null });
+    set({ user: null, isLoggedIn: false, error: null, hasHydrated: true });
     // 清除 localStorage
     try {
       localStorage.removeItem("blog-auth-user");
@@ -163,7 +169,7 @@ export const useAuthStore = create<AuthStore>((set) => ({
   },
 
   setUser: (user: AuthUser) => {
-    set({ user: normalizeAuthUser(user), isLoggedIn: true });
+    set({ user: normalizeAuthUser(user), isLoggedIn: true, hasHydrated: true });
   },
 
   updateAvatar: (avatarUrl: string) => {
@@ -195,5 +201,7 @@ export const initializeAuth = () => {
     }
   } catch (e) {
     console.error("Failed to restore auth state:", e);
+  } finally {
+    useAuthStore.setState({ hasHydrated: true });
   }
 };


### PR DESCRIPTION
- 新增 auth hydration 完成状态，避免初始化阶段过早重定向
- ProtectedRoute 在 hydration 完成前展示统一 loading 占位
- 刷新后恢复登录态时不再出现首屏误跳转/闪烁

验证：bun run build

注意：当前 develop 尚未合并 FE-017 基座，本 PR 会一并包含 FE-017 路由守卫改动