### PR TITLE
feat(auth): 移除登录和注册成功后的整页刷新

### DIFF
--- a/src/features/auth/components/LoginPopover.tsx
+++ b/src/features/auth/components/LoginPopover.tsx
@@ -76,7 +76,6 @@ export default function LoginPopover({ isOpen, onClose }: LoginPopoverProps) {
       loginForm.reset();
       setTimeout(() => {
         onClose();
-        window.location.reload();
       }, 300);
     } catch (err) {
       console.error("登录失败:", err);
@@ -90,7 +89,6 @@ export default function LoginPopover({ isOpen, onClose }: LoginPopoverProps) {
       registerForm.reset();
       setTimeout(() => {
         onClose();
-        window.location.reload();
       }, 300);
     } catch (err) {
       console.error("注册失败:", err);


### PR DESCRIPTION
背景
LoginPopover 在登录和注册成功后通过 window.location.reload() 强制整页刷新。这个方案虽然能让界面看起来“同步成功”，但会带来页面闪烁、状态重建成本高、登录态更新不够平滑等问题。

变更内容
移除登录成功后的整页刷新
移除注册成功后的整页刷新
保留原有的成功后关闭弹窗行为
依赖现有 auth store 的局部状态更新来刷新头部、头像和登录态展示

影响范围
src/features/auth/components/LoginPopover.tsx
如需联动展示，现有的 auth store 和 Header 会继续通过状态订阅自动更新，无需额外改动

验收结果
登录成功后不再触发整页刷新
注册成功后不再触发整页刷新
登录态、头像、头部展示可通过局部状态正确刷新
原有成功后的弹窗关闭行为保持不变

验证
已做定点检查，相关文件无类型或语法错误