### PR TITLE
feat: 切换文章详情为后端 API，并统一认证与接口处理

### DIFF
--- a/src/pages/ArticleDetailPage.tsx
+++ b/src/pages/ArticleDetailPage.tsx
@@ -12,6 +12,18 @@ import { sanitizeHtml } from "@/lib/sanitizeHtml";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 
+const CATEGORY_NAME_PATTERN = /^[\p{Script=Han}\p{L}\p{N}]+$/u;
+
+const getSafeCategoryName = (categoryName: string | null | undefined): string => {
+  const trimmedName = categoryName?.trim() || "";
+
+  if (!trimmedName || !CATEGORY_NAME_PATTERN.test(trimmedName)) {
+    return "未分类";
+  }
+
+  return trimmedName;
+};
+
 export default function ArticleDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -257,6 +269,11 @@ export default function ArticleDetailPage() {
             ))}
           </div>
         )}
+
+        <div className="mb-8 inline-flex items-center gap-2 rounded-full border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 px-4 py-2 text-sm text-gray-600 dark:text-gray-400 shadow-sm">
+          <span className="font-semibold text-gray-900 dark:text-white">分类:</span>
+          <span>{getSafeCategoryName(article.category?.name)}</span>
+        </div>
 
         {/* 文章内容 */}
         <section className="mb-12 rounded-3xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-6 shadow-sm md:p-8">


### PR DESCRIPTION
PR 描述

本次 PR 在完成与 develop 变基后，仅保留了文章详情页中未被 FE-005 覆盖的独特改动：对分类名称做白名单校验，避免后端异常值直接进入 DOM 展示。

主要改动

文章详情页在渲染分类名称前增加白名单校验，仅允许中文、字母、数字字符。
当分类名为空或不合法时，统一回退为“未分类”。
保持详情页现有的加载态、404 兜底、重试逻辑、评论区和正文展示行为不变。
验证

已完成类型检查。
已完成 [bun run build](vscode-file://vscode-app/d:/Program%20Files/vscode/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)，构建通过。