### PR TITLE
FE-016: 认证响应适配层（兼容后端 data 包裹结构）

### DIFF
--- a/src/api/apiClient.test.ts
+++ b/src/api/apiClient.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   isTokenExemptAuthEndpoint,
+  normalizeErrorMessage,
   resetUnauthorizedRedirectState,
   shouldHandleUnauthorizedResponse,
 } from '@/api/apiClient';
@@ -37,5 +38,33 @@ describe('shouldHandleUnauthorizedResponse', () => {
   it('never handles 401 responses for auth endpoints', () => {
     expect(shouldHandleUnauthorizedResponse('/auth/login')).toBe(false);
     expect(shouldHandleUnauthorizedResponse('/auth/refresh')).toBe(false);
+  });
+});
+
+describe('normalizeErrorMessage', () => {
+  it('uses backend message for business errors', () => {
+    expect(
+      normalizeErrorMessage({
+        message: 'Request failed',
+        response: {
+          data: {
+            message: '邮箱已被注册',
+          },
+          status: 409,
+        },
+      } as never)
+    ).toBe('邮箱已被注册');
+  });
+
+  it('falls back to the 401 default message when backend is silent', () => {
+    expect(
+      normalizeErrorMessage({
+        message: 'Request failed',
+        response: {
+          data: {},
+          status: 401,
+        },
+      } as never)
+    ).toBe('未授权，请先登录');
   });
 });

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -73,7 +73,7 @@ export const resetUnauthorizedRedirectState = (): void => {
   isRedirecting = false;
 };
 
-const normalizeErrorMessage = (error: AxiosError): string => {
+export const normalizeErrorMessage = (error: AxiosError): string => {
   const responseData = error.response?.data as
     | { message?: string; msg?: string }
     | string

--- a/src/api/auth.test.ts
+++ b/src/api/auth.test.ts
@@ -8,9 +8,35 @@ vi.mock('./apiClient', () => ({
   },
 }));
 
-const mockedPost = vi.mocked(apiClient.post);
+const mockedPost = apiClient.post as unknown as {
+  mockReset: () => void;
+  mockResolvedValueOnce: (value: unknown) => void;
+};
+
+function installLocalStorageMock() {
+  const storage = new Map<string, string>();
+
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      clear() {
+        storage.clear();
+      },
+      getItem(key: string) {
+        return storage.has(key) ? storage.get(key)! : null;
+      },
+      removeItem(key: string) {
+        storage.delete(key);
+      },
+      setItem(key: string, value: string) {
+        storage.set(key, value);
+      },
+    },
+  });
+}
 
 beforeEach(() => {
+  installLocalStorageMock();
   localStorage.clear();
   mockedPost.mockReset();
 });

--- a/src/api/auth.test.ts
+++ b/src/api/auth.test.ts
@@ -13,25 +13,35 @@ const mockedPost = apiClient.post as unknown as {
   mockResolvedValueOnce: (value: unknown) => void;
 };
 
+let localStorageMock: {
+  clear: () => void;
+  getItem: (key: string) => string | null;
+  removeItem: (key: string) => void;
+  setItem: ReturnType<typeof vi.fn>;
+};
+
 function installLocalStorageMock() {
   const storage = new Map<string, string>();
 
+  localStorageMock = {
+    clear() {
+      storage.clear();
+      localStorageMock.setItem.mockClear();
+    },
+    getItem(key: string) {
+      return storage.has(key) ? storage.get(key)! : null;
+    },
+    removeItem(key: string) {
+      storage.delete(key);
+    },
+    setItem: vi.fn((key: string, value: string) => {
+      storage.set(key, value);
+    }),
+  };
+
   Object.defineProperty(globalThis, 'localStorage', {
     configurable: true,
-    value: {
-      clear() {
-        storage.clear();
-      },
-      getItem(key: string) {
-        return storage.has(key) ? storage.get(key)! : null;
-      },
-      removeItem(key: string) {
-        storage.delete(key);
-      },
-      setItem(key: string, value: string) {
-        storage.set(key, value);
-      },
-    },
+    value: localStorageMock,
   });
 }
 
@@ -78,6 +88,32 @@ describe('auth api adapter', () => {
     expect(localStorage.getItem('accessToken')).toBe('access-token-1');
   });
 
+  it('rejects login responses without an access token and does not persist storage', async () => {
+    mockedPost.mockResolvedValueOnce({
+      data: {
+        message: 'Login successful',
+        data: {
+          user: {
+            user_id: 7,
+            username: 'Alice',
+            email: 'alice@example.com',
+            role_id: 1,
+          },
+          tokens: {
+            refresh_token: 'refresh-token-1',
+          },
+        },
+      },
+    });
+
+    await expect(
+      login({ email: 'alice@example.com', password: 'secret123' })
+    ).rejects.toThrow('登录响应缺少访问令牌');
+
+    expect(localStorage.getItem('accessToken')).toBeNull();
+    expect(localStorageMock.setItem).not.toHaveBeenCalled();
+  });
+
   it('builds register user from minimal response payload', async () => {
     mockedPost.mockResolvedValueOnce({
       data: {
@@ -105,6 +141,45 @@ describe('auth api adapter', () => {
     });
 
     expect(localStorage.getItem('accessToken')).toBeNull();
+  });
+
+  it('persists the access token when register response includes nested tokens', async () => {
+    mockedPost.mockResolvedValueOnce({
+      data: {
+        message: 'Registration successful',
+        data: {
+          user: {
+            user_id: 9,
+            username: 'Bob',
+            email: 'bob@example.com',
+            role_id: 0,
+          },
+          tokens: {
+            access_token: 'register-access-token',
+            refresh_token: 'register-refresh-token',
+          },
+        },
+      },
+    });
+
+    await expect(
+      register({
+        username: 'Bob',
+        email: 'bob@example.com',
+        password: 'secret123',
+        confirmPassword: 'secret123',
+        code: '123456',
+      })
+    ).resolves.toEqual({
+      id: 9,
+      username: 'Bob',
+      email: 'bob@example.com',
+      avatar: undefined,
+      role: 'user',
+    });
+
+    expect(localStorageMock.setItem).toHaveBeenCalledWith('accessToken', 'register-access-token');
+    expect(localStorage.getItem('accessToken')).toBe('register-access-token');
   });
 
   it('unwraps verification code response messages', async () => {
@@ -137,5 +212,23 @@ describe('auth api adapter', () => {
 
     await expect(refreshToken()).resolves.toBe('new-access-token');
     expect(localStorage.getItem('accessToken')).toBe('new-access-token');
+  });
+
+  it('rejects refresh responses without an access token and leaves storage unchanged', async () => {
+    localStorage.setItem('accessToken', 'existing-token');
+    mockedPost.mockResolvedValueOnce({
+      data: {
+        message: 'Token refreshed successfully',
+        data: {
+          tokens: {
+            refresh_token: 'new-refresh-token',
+          },
+        },
+      },
+    });
+
+    await expect(refreshToken()).rejects.toThrow('刷新令牌响应缺少访问令牌');
+    expect(localStorage.getItem('accessToken')).toBe('existing-token');
+    expect(localStorageMock.setItem).not.toHaveBeenCalledWith('accessToken', 'new-access-token');
   });
 });

--- a/src/api/auth.test.ts
+++ b/src/api/auth.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import apiClient from './apiClient';
+import { login, refreshToken, register, sendVerificationCode } from './auth';
+
+vi.mock('./apiClient', () => ({
+  default: {
+    post: vi.fn(),
+  },
+}));
+
+const mockedPost = vi.mocked(apiClient.post);
+
+beforeEach(() => {
+  localStorage.clear();
+  mockedPost.mockReset();
+});
+
+describe('auth api adapter', () => {
+  it('maps login response from backend envelope', async () => {
+    mockedPost.mockResolvedValueOnce({
+      data: {
+        message: 'Login successful',
+        data: {
+          user: {
+            user_id: 7,
+            username: 'Alice',
+            email: 'alice@example.com',
+            role_id: 1,
+          },
+          tokens: {
+            access_token: 'access-token-1',
+            refresh_token: 'refresh-token-1',
+          },
+        },
+      },
+    });
+
+    await expect(
+      login({ email: 'alice@example.com', password: 'secret123' })
+    ).resolves.toEqual({
+      user: {
+        id: 7,
+        username: 'Alice',
+        email: 'alice@example.com',
+        avatar: undefined,
+        role: 'admin',
+      },
+      accessToken: 'access-token-1',
+      refreshToken: 'refresh-token-1',
+    });
+
+    expect(localStorage.getItem('accessToken')).toBe('access-token-1');
+  });
+
+  it('builds register user from minimal response payload', async () => {
+    mockedPost.mockResolvedValueOnce({
+      data: {
+        message: 'Registration successful',
+        data: {
+          user_id: 9,
+        },
+      },
+    });
+
+    await expect(
+      register({
+        username: 'Bob',
+        email: 'bob@example.com',
+        password: 'secret123',
+        confirmPassword: 'secret123',
+        code: '123456',
+      })
+    ).resolves.toEqual({
+      id: 9,
+      username: 'Bob',
+      email: 'bob@example.com',
+      avatar: undefined,
+      role: 'user',
+    });
+
+    expect(localStorage.getItem('accessToken')).toBeNull();
+  });
+
+  it('unwraps verification code response messages', async () => {
+    mockedPost.mockResolvedValueOnce({
+      data: {
+        message: 'Verification code sent successfully',
+        data: {
+          message: 'Verification code sent successfully',
+        },
+      },
+    });
+
+    await expect(sendVerificationCode('alice@example.com')).resolves.toEqual({
+      message: 'Verification code sent successfully',
+    });
+  });
+
+  it('extracts refreshed access token from nested tokens', async () => {
+    mockedPost.mockResolvedValueOnce({
+      data: {
+        message: 'Token refreshed successfully',
+        data: {
+          tokens: {
+            access_token: 'new-access-token',
+            refresh_token: 'new-refresh-token',
+          },
+        },
+      },
+    });
+
+    await expect(refreshToken()).resolves.toBe('new-access-token');
+    expect(localStorage.getItem('accessToken')).toBe('new-access-token');
+  });
+});

--- a/src/api/auth.test.ts
+++ b/src/api/auth.test.ts
@@ -197,6 +197,19 @@ describe('auth api adapter', () => {
     });
   });
 
+  it('rejects invalid verification code responses without a string message', async () => {
+    mockedPost.mockResolvedValueOnce({
+      data: {
+        message: 'Verification code sent successfully',
+        data: {
+          message: null,
+        },
+      },
+    });
+
+    await expect(sendVerificationCode('alice@example.com')).rejects.toThrow('发送验证码响应格式无效');
+  });
+
   it('extracts refreshed access token from nested tokens', async () => {
     mockedPost.mockResolvedValueOnce({
       data: {

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -143,7 +143,12 @@ export const sendVerificationCode = async (email: string): Promise<{ message: st
   try {
     const response = await apiClient.post<ApiEnvelope<{ message: string }> | { message: string }>("/auth/sendcode", { email });
     const codeData = unwrapResponse(response.data);
-    return codeData as { message: string };
+
+    if (!codeData || typeof codeData !== 'object' || typeof codeData.message !== 'string') {
+      throw new Error('发送验证码响应格式无效');
+    }
+
+    return { message: codeData.message };
   } catch (error) {
     console.error("发送验证码失败:", error);
     throw error;

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,7 +1,48 @@
 import apiClient from './apiClient';
 import type { AuthUser, LoginForm, RegisterForm } from '../types/auth';
 
-// 定义登录响应类型
+interface ApiEnvelope<T> {
+  message: string;
+  data: T;
+  code?: string;
+  requestId?: string;
+}
+
+interface BackendAuthTokens {
+  token_type?: string;
+  access_token?: string;
+  refresh_token?: string;
+  accessToken?: string;
+  refreshToken?: string;
+  access_expires_at?: string;
+  refresh_expires_at?: string;
+}
+
+interface BackendAuthUser {
+  id?: number;
+  user_id?: number;
+  username?: string;
+  email?: string;
+  avatar?: string;
+  role_id?: number;
+  role?: AuthUser['role'];
+}
+
+interface BackendAuthPayload {
+  user?: BackendAuthUser;
+  tokens?: BackendAuthTokens;
+  access_token?: string;
+  refresh_token?: string;
+  accessToken?: string;
+  refreshToken?: string;
+  user_id?: number;
+  username?: string;
+  email?: string;
+  avatar?: string;
+  role_id?: number;
+  role?: AuthUser['role'];
+}
+
 interface LoginResponse {
   user: AuthUser;
   accessToken: string;
@@ -14,6 +55,56 @@ interface RegisterResponse {
   refreshToken?: string;
 }
 
+function unwrapResponse<T>(payload: ApiEnvelope<T> | T): T {
+  if (typeof payload === 'object' && payload !== null && 'data' in payload) {
+    return (payload as ApiEnvelope<T>).data;
+  }
+
+  return payload as T;
+}
+
+function resolveRole(roleId?: number, role?: AuthUser['role']): AuthUser['role'] {
+  if (role) {
+    return role;
+  }
+
+  switch (roleId) {
+    case 1:
+      return 'admin';
+    case 2:
+      return 'superadmin';
+    default:
+      return 'user';
+  }
+}
+
+function mapAuthUser(payload: BackendAuthUser, fallback?: Partial<AuthUser>): AuthUser {
+  const id = payload.id ?? payload.user_id ?? fallback?.id;
+  const username = payload.username ?? fallback?.username;
+  const email = payload.email ?? fallback?.email;
+
+  if (id === undefined || !username || !email) {
+    throw new Error('认证响应缺少用户信息');
+  }
+
+  return {
+    id,
+    username,
+    email,
+    avatar: payload.avatar ?? fallback?.avatar,
+    role: resolveRole(payload.role_id, payload.role ?? fallback?.role),
+  };
+}
+
+function resolveAuthTokens(payload: BackendAuthPayload): { accessToken?: string; refreshToken?: string } {
+  const tokens = payload.tokens ?? payload;
+
+  return {
+    accessToken: tokens.access_token ?? tokens.accessToken,
+    refreshToken: tokens.refresh_token ?? tokens.refreshToken,
+  };
+}
+
 /**
  * 用户登录
  * @param credentials 登录凭证（邮箱和密码）
@@ -21,14 +112,22 @@ interface RegisterResponse {
  */
 export const login = async (credentials: LoginForm): Promise<LoginResponse> => {
   try {
-    const response = await apiClient.post<{ data: LoginResponse; code?: number; message?: string } | LoginResponse>('/auth/login', credentials);
-    // 后端返回的数据结构可能是 { data: { user, accessToken, refreshToken } } 或者直接是 { user, accessToken, refreshToken }
-    const loginData = (response.data as any)?.data || response.data;
-    // 登录成功后保存token到localStorage
-    if (loginData.accessToken) {
-      localStorage.setItem('accessToken', loginData.accessToken);
+    const response = await apiClient.post<ApiEnvelope<BackendAuthPayload> | BackendAuthPayload>('/auth/login', credentials);
+    const loginData = unwrapResponse(response.data);
+    const user = mapAuthUser(loginData.user ?? loginData);
+    const { accessToken, refreshToken } = resolveAuthTokens(loginData);
+
+    if (!accessToken) {
+      throw new Error('登录响应缺少访问令牌');
     }
-    return loginData as LoginResponse;
+
+    localStorage.setItem('accessToken', accessToken);
+
+    return {
+      user,
+      accessToken,
+      refreshToken: refreshToken ?? '',
+    };
   } catch (error) {
     console.error('登录失败:', error);
     throw error;
@@ -42,8 +141,8 @@ export const login = async (credentials: LoginForm): Promise<LoginResponse> => {
  */
 export const sendVerificationCode = async (email: string): Promise<{ message: string }> => {
   try {
-    const response = await apiClient.post<{ message: string }>("/auth/sendcode", { email });
-    const codeData = (response.data as any)?.data || response.data;
+    const response = await apiClient.post<ApiEnvelope<{ message: string }> | { message: string }>("/auth/sendcode", { email });
+    const codeData = unwrapResponse(response.data);
     return codeData as { message: string };
   } catch (error) {
     console.error("发送验证码失败:", error);
@@ -58,15 +157,21 @@ export const sendVerificationCode = async (email: string): Promise<{ message: st
  */
 export const register = async (userData: RegisterForm): Promise<AuthUser> => {
   try {
-    const response = await apiClient.post<{ data: RegisterResponse; code?: number; message?: string } | RegisterResponse>('/auth/register', userData);
-    // 后端可能返回 { data: { user, accessToken } } 或直接返回 { user, accessToken }
-    const registerData = 'data' in response.data ? response.data.data : response.data;
-    const user = registerData.user;
-    // 如果注册返回 token，保存到 localStorage
-    if (registerData.accessToken) {
-      localStorage.setItem('accessToken', registerData.accessToken);
+    const response = await apiClient.post<ApiEnvelope<BackendAuthPayload> | BackendAuthPayload>('/auth/register', userData);
+    const registerData = unwrapResponse(response.data);
+    const user = mapAuthUser(registerData.user ?? registerData, {
+      id: registerData.user?.id ?? registerData.user?.user_id ?? registerData.user_id,
+      username: userData.username,
+      email: userData.email,
+      role: 'user',
+    });
+    const { accessToken } = resolveAuthTokens(registerData);
+
+    if (accessToken) {
+      localStorage.setItem('accessToken', accessToken);
     }
-    return user as AuthUser;
+
+    return user;
   } catch (error) {
     console.error('注册失败:', error);
     throw error;
@@ -95,12 +200,16 @@ export const logout = async (): Promise<void> => {
  */
 export const refreshToken = async (): Promise<string> => {
   try {
-    const response = await apiClient.post('/auth/refresh');
-    const newToken = response.data.accessToken;
-    if (newToken) {
-      localStorage.setItem('accessToken', newToken);
+    const response = await apiClient.post<ApiEnvelope<BackendAuthPayload> | BackendAuthPayload>('/auth/refresh');
+    const refreshData = unwrapResponse(response.data);
+    const { accessToken } = resolveAuthTokens(refreshData);
+
+    if (!accessToken) {
+      throw new Error('刷新令牌响应缺少访问令牌');
     }
-    return newToken;
+
+    localStorage.setItem('accessToken', accessToken);
+    return accessToken;
   } catch (error) {
     console.error('刷新令牌失败:', error);
     throw error;

--- a/src/store/authStore.test.ts
+++ b/src/store/authStore.test.ts
@@ -8,9 +8,19 @@ vi.mock('@/api/auth', () => ({
   sendVerificationCode: vi.fn(),
 }));
 
-import { login as apiLogin } from '@/api/auth';
+import { login as apiLogin, logout as apiLogout, register as apiRegister } from '@/api/auth';
 
 const mockedLogin = apiLogin as unknown as {
+  mockReset: () => void;
+  mockResolvedValueOnce: (value: unknown) => void;
+};
+
+const mockedRegister = apiRegister as unknown as {
+  mockReset: () => void;
+  mockResolvedValueOnce: (value: unknown) => void;
+};
+
+const mockedLogout = apiLogout as unknown as {
   mockReset: () => void;
   mockResolvedValueOnce: (value: unknown) => void;
 };
@@ -41,6 +51,8 @@ beforeEach(() => {
   installLocalStorageMock();
   localStorage.clear();
   mockedLogin.mockReset();
+  mockedRegister.mockReset();
+  mockedLogout.mockReset();
   useAuthStore.setState({
     user: null,
     isLoading: false,
@@ -87,5 +99,76 @@ describe('useAuthStore login flow', () => {
       role: 'admin',
     }));
     expect(localStorage.getItem('accessToken')).toBe('token-abc');
+  });
+});
+
+describe('useAuthStore register flow', () => {
+  it('stores the mapped user after register', async () => {
+    mockedRegister.mockResolvedValueOnce({
+      id: 8,
+      username: 'Dora',
+      email: 'dora@example.com',
+      role: 'user',
+    });
+
+    await useAuthStore.getState().register({
+      username: 'Dora',
+      email: 'dora@example.com',
+      password: 'secret123',
+      confirmPassword: 'secret123',
+      code: '123456',
+    });
+
+    const state = useAuthStore.getState();
+
+    expect(state.isLoggedIn).toBe(true);
+    expect(state.user).toEqual({
+      id: 8,
+      username: 'Dora',
+      email: 'dora@example.com',
+      role: 'user',
+    });
+    expect(localStorage.getItem('blog-auth-user')).toBe(JSON.stringify({
+      id: 8,
+      username: 'Dora',
+      email: 'dora@example.com',
+      role: 'user',
+    }));
+  });
+});
+
+describe('useAuthStore logout flow', () => {
+  it('clears auth state and storage after logout', async () => {
+    localStorage.setItem('blog-auth-user', JSON.stringify({
+      id: 9,
+      username: 'Eve',
+      email: 'eve@example.com',
+      role: 'user',
+    }));
+    localStorage.setItem('accessToken', 'token-logout');
+
+    useAuthStore.setState({
+      user: {
+        id: 9,
+        username: 'Eve',
+        email: 'eve@example.com',
+        role: 'user',
+      },
+      isLoggedIn: true,
+      isLoading: false,
+      error: null,
+      hasHydrated: true,
+    });
+
+    mockedLogout.mockResolvedValueOnce(undefined);
+
+    await useAuthStore.getState().logout();
+
+    const state = useAuthStore.getState();
+
+    expect(state.user).toBeNull();
+    expect(state.isLoggedIn).toBe(false);
+    expect(localStorage.getItem('blog-auth-user')).toBeNull();
+    expect(localStorage.getItem('accessToken')).toBeNull();
   });
 });

--- a/src/store/authStore.test.ts
+++ b/src/store/authStore.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAuthStore } from '@/store/authStore';
+
+vi.mock('@/api/auth', () => ({
+  login: vi.fn(),
+  register: vi.fn(),
+  logout: vi.fn(),
+  sendVerificationCode: vi.fn(),
+}));
+
+import { login as apiLogin } from '@/api/auth';
+
+const mockedLogin = apiLogin as unknown as {
+  mockReset: () => void;
+  mockResolvedValueOnce: (value: unknown) => void;
+};
+
+function installLocalStorageMock() {
+  const storage = new Map<string, string>();
+
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      clear() {
+        storage.clear();
+      },
+      getItem(key: string) {
+        return storage.has(key) ? storage.get(key)! : null;
+      },
+      removeItem(key: string) {
+        storage.delete(key);
+      },
+      setItem(key: string, value: string) {
+        storage.set(key, value);
+      },
+    },
+  });
+}
+
+beforeEach(() => {
+  installLocalStorageMock();
+  localStorage.clear();
+  mockedLogin.mockReset();
+  useAuthStore.setState({
+    user: null,
+    isLoading: false,
+    error: null,
+    isLoggedIn: false,
+    hasHydrated: false,
+    isSendingCode: false,
+    countdown: 0,
+    timerId: null,
+  });
+});
+
+describe('useAuthStore login flow', () => {
+  it('stores the mapped user and token after login', async () => {
+    mockedLogin.mockResolvedValueOnce({
+      user: {
+        id: 3,
+        username: 'Carol',
+        email: 'carol@example.com',
+        role: 'admin',
+      },
+      accessToken: 'token-abc',
+      refreshToken: 'refresh-abc',
+    });
+
+    await useAuthStore.getState().login({
+      email: 'carol@example.com',
+      password: 'secret123',
+    });
+
+    const state = useAuthStore.getState();
+
+    expect(state.isLoggedIn).toBe(true);
+    expect(state.user).toEqual({
+      id: 3,
+      username: 'Carol',
+      email: 'carol@example.com',
+      role: 'admin',
+    });
+    expect(localStorage.getItem('blog-auth-user')).toBe(JSON.stringify({
+      id: 3,
+      username: 'Carol',
+      email: 'carol@example.com',
+      role: 'admin',
+    }));
+    expect(localStorage.getItem('accessToken')).toBe('token-abc');
+  });
+});


### PR DESCRIPTION
本次改动为认证链路新增了响应适配层，前端不再直接依赖后端扁平返回结构，而是统一先解包data再映射为前端可消费的数据格式。

主要变更

在 src/api/auth.ts 中新增响应解包与认证数据映射逻辑。
登录接口已兼容后端data.tokens.access_token和data.tokens.refresh_token结构。
注册接口已兼容后端当前返回结构。
刷新 token 接口已兼容后端嵌套返回结构。
在 src/api/apiClient.ts 中补充错误消息归一化，避免 401 和业务错误提示回退为 undefined。
在 src/store/authStore.ts 对应补充登录、注册、登出链路测试，验证认证状态与本地存储行为。

验证

bun test src/api/auth.test.ts
bun test src/api/apiClient.test.ts
bun test src/store/authStore.test.ts
bun test src/api/auth.test.ts src/store/authStore.test.ts src/api/apiClient.test.ts

备注

这次改动保持在认证链路的最小范围内，没有扩展到 UI 或其他业务模块。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了错误消息的规范化处理，提供更准确的错误提示。

* **Tests**
  * 为认证流程（登录、注册、令牌刷新）增加了全面的单元测试覆盖。
  * 为错误处理增加了单元测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->