### PR TITLE
FE-009: 接入文章 CRUD 后端 API

### DIFF
--- a/src/api/article.test.ts
+++ b/src/api/article.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import apiClient from './apiClient';
+import { articleApi } from './article';
+
+vi.mock('./apiClient', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+const mockedApiClient = apiClient as unknown as {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+};
+
+beforeEach(() => {
+  mockedApiClient.get.mockReset();
+  mockedApiClient.post.mockReset();
+  mockedApiClient.put.mockReset();
+  mockedApiClient.delete.mockReset();
+});
+
+describe('article api adapter', () => {
+  it('creates article from backend envelope response', async () => {
+    mockedApiClient.post.mockResolvedValueOnce({
+      data: {
+        data: {
+          id: 42,
+          title: 'Hello World',
+          summary: 'First article',
+          cover_image: '',
+          content: '<p>content</p>',
+          author: {
+            id: 7,
+            username: 'Alice',
+          },
+          tags: [],
+          category: null,
+          view_count: 0,
+          created_at: '2026-04-13T08:00:00Z',
+          updated_at: '2026-04-13T08:00:00Z',
+        },
+      },
+    });
+
+    await expect(
+      articleApi.create({
+        title: 'Hello World',
+        content: '<p>content</p>',
+        summary: 'First article',
+      })
+    ).resolves.toEqual({
+      id: 42,
+      title: 'Hello World',
+      summary: 'First article',
+      cover_image: '',
+      author: {
+        id: 7,
+        username: 'Alice',
+      },
+      view_count: 0,
+      created_at: '2026-04-13T08:00:00Z',
+      updated_at: '2026-04-13T08:00:00Z',
+      content: '<p>content</p>',
+      tags: [],
+      category: null,
+    });
+
+    expect(mockedApiClient.post).toHaveBeenCalledWith(
+      '/articles',
+      {
+        title: 'Hello World',
+        content: '<p>content</p>',
+        summary: 'First article',
+      },
+      { signal: undefined }
+    );
+  });
+
+  it('updates article with the expected endpoint and payload', async () => {
+    mockedApiClient.put.mockResolvedValueOnce({
+      data: {
+        message: 'Article updated successfully',
+      },
+    });
+
+    await expect(
+      articleApi.update(42, {
+        title: 'Updated title',
+        status: 'published',
+      })
+    ).resolves.toBeUndefined();
+
+    expect(mockedApiClient.put).toHaveBeenCalledWith(
+      '/articles/42',
+      {
+        title: 'Updated title',
+        status: 'published',
+      },
+      { signal: undefined }
+    );
+  });
+
+  it('deletes article through the expected endpoint', async () => {
+    mockedApiClient.delete.mockResolvedValueOnce({
+      data: {
+        message: 'Article deleted successfully',
+      },
+    });
+
+    await expect(articleApi.delete(42)).resolves.toBeUndefined();
+
+    expect(mockedApiClient.delete).toHaveBeenCalledWith('/articles/42', { signal: undefined });
+  });
+});

--- a/src/api/article.ts
+++ b/src/api/article.ts
@@ -42,6 +42,30 @@ export interface ArticleListRequestOptions {
   signal?: AbortSignal;
 }
 
+export type ArticlePublishStatus = 'draft' | 'published';
+
+export type ArticleEditableStatus = ArticlePublishStatus | 'archived';
+
+export interface ArticleCreateRequest {
+  title: string;
+  content: string;
+  summary?: string;
+  cover_image?: string;
+  status?: ArticlePublishStatus;
+}
+
+export interface ArticleUpdateRequest {
+  title?: string;
+  content?: string;
+  summary?: string;
+  cover_image?: string;
+  status?: ArticleEditableStatus;
+}
+
+export interface ArticleMutationRequestOptions {
+  signal?: AbortSignal;
+}
+
 export interface ArticlePagination {
   page: number;
   page_size: number;
@@ -212,5 +236,32 @@ export const articleApi = {
     });
 
     return normalizeArticleDetail(unwrapResponse(response.data));
+  },
+
+  create: async (
+    payload: ArticleCreateRequest,
+    options: ArticleMutationRequestOptions = {}
+  ): Promise<ArticleDetail> => {
+    const response = await apiClient.post<ArticleDetail | { data: ArticleDetail }>('/articles', payload, {
+      signal: options.signal,
+    });
+
+    return normalizeArticleDetail(unwrapResponse(response.data));
+  },
+
+  update: async (
+    id: number,
+    payload: ArticleUpdateRequest,
+    options: ArticleMutationRequestOptions = {}
+  ): Promise<void> => {
+    await apiClient.put(`/articles/${id}`, payload, {
+      signal: options.signal,
+    });
+  },
+
+  delete: async (id: number, options: ArticleMutationRequestOptions = {}): Promise<void> => {
+    await apiClient.delete(`/articles/${id}`, {
+      signal: options.signal,
+    });
   },
 };

--- a/src/api/article.ts
+++ b/src/api/article.ts
@@ -23,6 +23,7 @@ export interface Article {
   author: ArticleAuthor;
   view_count: number;
   created_at: string;
+  updated_at: string;
 }
 
 export interface ArticleDetail extends Article {
@@ -148,6 +149,7 @@ const normalizeArticle = (article: Partial<Article> & { author?: Partial<Article
   author: normalizeArticleAuthor(article.author),
   view_count: typeof article.view_count === "number" ? article.view_count : 0,
   created_at: article.created_at?.trim() || "",
+  updated_at: article.updated_at?.trim() || "",
 });
 
 const normalizeArticleDetail = (

--- a/src/features/articles/utils/articleFormAdapter.ts
+++ b/src/features/articles/utils/articleFormAdapter.ts
@@ -1,0 +1,14 @@
+import { type ArticleDetail } from "@/api/article";
+import type { Post } from "@/types";
+
+export const toArticleFormPost = (article: ArticleDetail): Post => {
+  return {
+    id: article.id,
+    title: article.title,
+    summary: article.summary,
+    content: article.content,
+    tags: Array.isArray(article.tags) ? article.tags.map((tag) => tag.name) : [],
+    createdAt: article.created_at ? article.created_at.slice(0, 10) : undefined,
+    author: article.author?.username,
+  };
+};

--- a/src/pages/AdminDashboardPage.tsx
+++ b/src/pages/AdminDashboardPage.tsx
@@ -6,6 +6,8 @@ import { PlusIcon, Pencil1Icon, TrashIcon } from "@radix-ui/react-icons";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 
+const ADMIN_ARTICLES_PAGE_SIZE = 100;
+
 export default function AdminDashboardPage() {
   const navigate = useNavigate();
   const [articles, setArticles] = useState<Article[]>([]);
@@ -20,7 +22,7 @@ export default function AdminDashboardPage() {
     setError(null);
 
     articleApi
-      .list({ page_size: 100 })
+      .list({ page_size: ADMIN_ARTICLES_PAGE_SIZE })
       .then((response) => {
         if (isActive) {
           setArticles(response.items);

--- a/src/pages/AdminDashboardPage.tsx
+++ b/src/pages/AdminDashboardPage.tsx
@@ -1,28 +1,66 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { usePostStore } from "@/store/postStore";
+import { articleApi, type Article } from "@/api/article";
 import { CommentManagement } from "@/features/comments/components/CommentManagement";
 import { PlusIcon, Pencil1Icon, TrashIcon } from "@radix-ui/react-icons";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 
 export default function AdminDashboardPage() {
   const navigate = useNavigate();
-  const { posts, fetchPosts } = usePostStore();
+  const [articles, setArticles] = useState<Article[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<'articles' | 'comments'>('articles');
 
   useEffect(() => {
-    fetchPosts();
-  }, [fetchPosts]);
+    let isActive = true;
 
-  const handleDelete = (id: number) => {
+    setIsLoading(true);
+    setError(null);
+
+    articleApi
+      .list({ page_size: 100 })
+      .then((response) => {
+        if (isActive) {
+          setArticles(response.items);
+        }
+      })
+      .catch((requestError) => {
+        if (!isActive) {
+          return;
+        }
+
+        const message = requestError instanceof Error ? requestError.message : "获取文章列表失败";
+        setError(message);
+        setArticles([]);
+      })
+      .finally(() => {
+        if (isActive) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      isActive = false;
+    };
+  }, []);
+
+  const handleDelete = async (id: number) => {
     if (window.confirm("确定要删除这篇文章吗？")) {
-      // 调用 store 的 deletePost，但我们需要更新 store
-      // 这里先提示用户
-      alert("删除功能需要后端 API 支持");
+      try {
+        await articleApi.delete(id);
+        setArticles((currentArticles) => currentArticles.filter((article) => article.id !== id));
+        alert("文章删除成功！");
+      } catch (requestError) {
+        const message = requestError instanceof Error ? requestError.message : "删除文章失败";
+        alert(message);
+      }
     }
   };
+
+  const totalViews = articles.reduce((sum, article) => sum + article.view_count, 0);
+  const recentArticleDate = articles[0]?.created_at ? new Date(articles[0].created_at).toLocaleDateString() : "-";
 
   return (
     <div>
@@ -80,25 +118,21 @@ export default function AdminDashboardPage() {
             <Card>
               <CardContent className="p-6">
                 <div className="text-gray-500 dark:text-gray-400 text-sm font-medium mb-2">总文章数</div>
-                <div className="text-3xl font-bold text-gray-900 dark:text-white">{posts.length}</div>
+                <div className="text-3xl font-bold text-gray-900 dark:text-white">{articles.length}</div>
               </CardContent>
             </Card>
             <Card>
               <CardContent className="p-6">
                 <div className="text-gray-500 dark:text-gray-400 text-sm font-medium mb-2">最近更新</div>
                 <div className="text-lg font-semibold text-gray-900 dark:text-white">
-                {posts[0]?.createdAt 
-                  ? new Date(posts[0].createdAt).toLocaleDateString() 
-                  : "-"}
+                {recentArticleDate}
                 </div>
               </CardContent>
             </Card>
             <Card>
               <CardContent className="p-6">
-                <div className="text-gray-500 dark:text-gray-400 text-sm font-medium mb-2">总标签数</div>
-                <div className="text-3xl font-bold text-gray-900 dark:text-white">
-                {new Set(posts.flatMap((p) => p.tags)).size}
-                </div>
+                <div className="text-gray-500 dark:text-gray-400 text-sm font-medium mb-2">总阅读量</div>
+                <div className="text-3xl font-bold text-gray-900 dark:text-white">{totalViews}</div>
               </CardContent>
             </Card>
           </div>
@@ -112,10 +146,13 @@ export default function AdminDashboardPage() {
                     标题
                   </th>
                   <th className="px-6 py-4 text-left text-sm font-semibold text-gray-900 dark:text-white">
-                    标签
+                    作者
                   </th>
                   <th className="px-6 py-4 text-left text-sm font-semibold text-gray-900 dark:text-white">
                     发布日期
+                  </th>
+                  <th className="px-6 py-4 text-left text-sm font-semibold text-gray-900 dark:text-white">
+                    阅读量
                   </th>
                   <th className="px-6 py-4 text-right text-sm font-semibold text-gray-900 dark:text-white">
                     操作
@@ -123,9 +160,21 @@ export default function AdminDashboardPage() {
                 </tr>
               </thead>
               <tbody>
-                {posts.length === 0 ? (
+                {isLoading ? (
                   <tr>
-                    <td colSpan={4} className="px-6 py-8 text-center text-gray-500 dark:text-gray-400">
+                    <td colSpan={5} className="px-6 py-8 text-center text-gray-500 dark:text-gray-400">
+                      正在加载文章列表...
+                    </td>
+                  </tr>
+                ) : error ? (
+                  <tr>
+                    <td colSpan={5} className="px-6 py-8 text-center text-red-600 dark:text-red-400">
+                      {error}
+                    </td>
+                  </tr>
+                ) : articles.length === 0 ? (
+                  <tr>
+                    <td colSpan={5} className="px-6 py-8 text-center text-gray-500 dark:text-gray-400">
                       暂无文章，
                       <Button
                         type="button"
@@ -138,45 +187,33 @@ export default function AdminDashboardPage() {
                     </td>
                   </tr>
                 ) : (
-                  posts.map((post) => (
+                  articles.map((article) => (
                     <tr
-                      key={post.id}
+                      key={article.id}
                       className="border-b border-gray-200 transition-colors hover:bg-gray-50 dark:border-gray-800 dark:hover:bg-gray-800/50"
                     >
                       <td className="px-6 py-4">
-                        <div className="font-medium text-gray-900 dark:text-white">{post.title}</div>
+                        <div className="font-medium text-gray-900 dark:text-white">{article.title}</div>
                         <p className="text-sm text-gray-600 dark:text-gray-400 mt-1 line-clamp-1">
-                          {post.summary}
+                          {article.summary}
                         </p>
                       </td>
                       <td className="px-6 py-4">
-                        <div className="flex flex-wrap gap-1">
-                          {post.tags.slice(0, 2).map((tag) => (
-                            <Badge
-                              key={tag}
-                              variant="secondary"
-                              className="text-xs"
-                            >
-                              {tag}
-                            </Badge>
-                          ))}
-                          {post.tags.length > 2 && (
-                            <span className="text-xs text-gray-500 dark:text-gray-400">
-                              +{post.tags.length - 2}
-                            </span>
-                          )}
+                        <div className="text-sm text-gray-600 dark:text-gray-400">
+                          {article.author.username}
                         </div>
                       </td>
                       <td className="px-6 py-4 text-sm text-gray-600 dark:text-gray-400">
-                        {post.createdAt 
-                          ? new Date(post.createdAt).toLocaleDateString() 
-                          : "-"}
+                        {article.created_at ? new Date(article.created_at).toLocaleDateString() : "-"}
+                      </td>
+                      <td className="px-6 py-4 text-sm text-gray-600 dark:text-gray-400">
+                        {article.view_count}
                       </td>
                       <td className="px-6 py-4 text-right">
                         <div className="flex items-center justify-end gap-2">
                           <Button
                             type="button"
-                            onClick={() => navigate(`/admin/edit/${post.id}`)}
+                            onClick={() => navigate(`/admin/edit/${article.id}`)}
                             variant="ghost"
                             className="h-9 w-9 p-0 text-blue-600 hover:bg-blue-50 hover:text-blue-700 dark:text-blue-400 dark:hover:bg-blue-950/40"
                             title="编辑"
@@ -185,7 +222,7 @@ export default function AdminDashboardPage() {
                           </Button>
                           <Button
                             type="button"
-                            onClick={() => handleDelete(post.id)}
+                            onClick={() => handleDelete(article.id)}
                             variant="ghost"
                             className="h-9 w-9 p-0 text-red-600 hover:bg-red-50 hover:text-red-700 dark:text-red-400 dark:hover:bg-red-950/40"
                             title="删除"

--- a/src/pages/CreateArticlePage.tsx
+++ b/src/pages/CreateArticlePage.tsx
@@ -1,22 +1,31 @@
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import ArticleForm from "@/features/articles/components/ArticleForm";
-import { usePostStore } from "@/store/postStore";
+import { articleApi } from "@/api/article";
 import type { Post } from "@/types";
 
 export default function CreateArticlePage() {
   const navigate = useNavigate();
-  const { addPost } = usePostStore();
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const handleSubmit = (data: Post) => {
-    // 模拟保存（实际开发中这里应该调用后端 API）
-    console.log("新建文章:", data);
-    addPost(data);
+  const handleSubmit = async (data: Post) => {
+    setIsSubmitting(true);
 
-    // 显示成功提示
-    alert("文章发布成功！");
+    try {
+      await articleApi.create({
+        title: data.title,
+        content: data.content ?? "",
+        summary: data.summary,
+      });
 
-    // 返回管理后台
-    navigate("/admin");
+      alert("文章发布成功！");
+      navigate("/admin");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "文章发布失败";
+      alert(message);
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   return (
@@ -26,7 +35,7 @@ export default function CreateArticlePage() {
         <p className="text-gray-600 mt-2">填写下面的表单发布一篇新文章</p>
       </div>
 
-      <ArticleForm onSubmit={handleSubmit} />
+      <ArticleForm onSubmit={handleSubmit} isLoading={isSubmitting} />
     </div>
   );
 }

--- a/src/pages/EditArticlePage.tsx
+++ b/src/pages/EditArticlePage.tsx
@@ -1,7 +1,8 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import ArticleForm from "@/features/articles/components/ArticleForm";
-import { usePostStore } from "@/store/postStore";
+import { articleApi } from "@/api/article";
+import { toArticleFormPost } from "@/features/articles/utils/articleFormAdapter";
 import type { Post } from "@/types";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -9,27 +10,75 @@ import { Card, CardContent } from "@/components/ui/card";
 export default function EditArticlePage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const { currentPost, fetchPostById, updatePost, isLoading, error } =
-    usePostStore();
+  const [currentPost, setCurrentPost] = useState<Post | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (id) {
-      fetchPostById(Number(id));
-    }
-  }, [id, fetchPostById]);
+    const articleId = Number(id);
 
-  const handleSubmit = (data: Post) => {
+    if (!id || Number.isNaN(articleId)) {
+      setCurrentPost(null);
+      setError("文章不存在");
+      setIsLoading(false);
+      return;
+    }
+
+    let isActive = true;
+
+    setIsLoading(true);
+    setError(null);
+
+    articleApi
+      .getById(articleId)
+      .then((article) => {
+        if (!isActive) {
+          return;
+        }
+
+        setCurrentPost(toArticleFormPost(article));
+      })
+      .catch((requestError) => {
+        if (!isActive) {
+          return;
+        }
+
+        const message = requestError instanceof Error ? requestError.message : "获取文章失败";
+        setCurrentPost(null);
+        setError(message);
+      })
+      .finally(() => {
+        if (isActive) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      isActive = false;
+    };
+  }, [id]);
+
+  const handleSubmit = async (data: Post) => {
     if (!id) return;
 
-    // 模拟保存（实际开发中这里应该调用后端 API）
-    console.log("更新文章:", data);
-    updatePost(Number(id), data);
+    setIsSubmitting(true);
 
-    // 显示成功提示
-    alert("文章更新成功！");
+    try {
+      await articleApi.update(Number(id), {
+        title: data.title,
+        content: data.content ?? "",
+        summary: data.summary,
+      });
 
-    // 返回管理后台
-    navigate("/admin");
+      alert("文章更新成功！");
+      navigate("/admin");
+    } catch (requestError) {
+      const message = requestError instanceof Error ? requestError.message : "文章更新失败";
+      alert(message);
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   if (isLoading) {
@@ -67,7 +116,7 @@ export default function EditArticlePage() {
         <p className="text-gray-600 mt-2">修改文章内容并保存更改</p>
       </div>
 
-      <ArticleForm initialData={currentPost} onSubmit={handleSubmit} />
+      <ArticleForm initialData={currentPost} onSubmit={handleSubmit} isLoading={isSubmitting} />
     </div>
   );
 }


### PR DESCRIPTION
## 变更摘要
- 为文章 API 补齐 `create` / `update` / `delete` 能力。
- 创建页、编辑页、管理后台列表切换到后端真实接口。
- 新增文章表单适配器与 `articleApi` 契约测试。

## 验证
- `bun test src/api/article.test.ts`
- `bun run build`

## 说明
- 本次改动保持在 FE-009 约束范围内，未扩展到图片上传、富文本替换或认证模块。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加文章创建、更新和删除操作支持
  * 完善后台管理仪表板展示，新增阅读量指标和作者列

* **测试**
  * 新增文章API接口的测试套件

<!-- end of auto-generated comment: release notes by coderabbit.ai -->